### PR TITLE
Work around docker-compose bug #919 (missing /bin/echo)

### DIFF
--- a/data/Dockerfile
+++ b/data/Dockerfile
@@ -6,6 +6,6 @@ COPY . /
 # Thanks to tianon
 # Haiku by way of credit
 # https://github.com/tianon/dockerfiles
-COPY true-asm /bin/:
+COPY true-asm /bin/echo
 VOLUME ["/srv/magento", "/var/lib/mysql"]
-ENTRYPOINT ["/bin/:"]
+ENTRYPOINT ["/bin/echo"]


### PR DESCRIPTION
I am not sure if this is a proper workaround, but it looks like it works for me.

I was unable to restart data only container after it was started once. I got the following error:

```
(M=71433 *1 ?3) az@ares p4 ~/docker-magento> docker-compose up
Recreating dockermagento_data_1...
Cannot start container dad3c1c01745482fd28bea85accfca4d5110036e32b85dd2b286d0c0e5b472eb: [8] System error: exec: "/bin/echo": stat /bin/echo: no such file or directory
```

But with this fix, it works now.

The original docker-compose bug: https://github.com/docker/compose/issues/919