### PR TITLE
Fix jpeg thumbnail creation

### DIFF
--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -5,8 +5,10 @@ RUN apt-get -qqy update \
                          libcurl4-gnutls-dev \
                          libmcrypt-dev \
                          libpng12-dev \
+                         libjpeg62-turbo-dev \
                          libxml2-dev \
                          libxslt-dev \
+ && docker-php-ext-configure gd --with-jpeg-dir=/usr/include/ \
  && docker-php-ext-install curl \
                            bcmath \
                            gd \


### PR DESCRIPTION
Hey,

Took me quite some time to figure out why thumbnails were not displayed when I run magento from docker. It seems that when installing php extensions via `docker-php-ext-install gd` it is not configured same way as when running `apt-get php5-gd`. I have added `libjpeg62-turbo-dev` to php container and configured `gd` to use it. Now even when cleaning cache, thumbnails are generated again :)

https://hub.docker.com/_/php/